### PR TITLE
Fixes Platypus such that it can be interrupted with ctrl-c

### DIFF
--- a/extensions/DeNovo/bayesianDeNovoFilter.py
+++ b/extensions/DeNovo/bayesianDeNovoFilter.py
@@ -95,7 +95,7 @@ class Variant(object):
             try:
                 key,value = item.split("=")
                 self.info[key] = value.split(",")
-            except:
+            except Exception:
                 pass
                 #print item
                 #raise
@@ -522,7 +522,7 @@ if __name__ == "__main__":
 
     try:
         extension = sys.argv[3]
-    except:
+    except Exception:
         extension = ""
 
     # Make output files using the name of the input VCF with various extensions

--- a/scripts/binIndelRatioByHP.py
+++ b/scripts/binIndelRatioByHP.py
@@ -56,7 +56,7 @@ def summariseVariantCalls(binSize):
                     nInsertions[hp//binSize] += 1
                 else:
                     pass
-        except:
+        except Exception:
             print "Error. Prob last line..."
             print line
             continue

--- a/scripts/binIndelRatioByPal.py
+++ b/scripts/binIndelRatioByPal.py
@@ -45,7 +45,7 @@ def summariseVariantCalls(binSize):
                 nDeletions[pal//binSize] += 1
             else:
                 nInsertions[pal//binSize] += 1
-        except:
+        except Exception:
             print "Error. Prob last line..."
             print line
             continue

--- a/scripts/binTsTvByHP.py
+++ b/scripts/binTsTvByHP.py
@@ -48,7 +48,7 @@ def summariseVariantCalls(binSize):
                 nTs[pal//binSize] += 1
             else:
                 nTv[pal//binSize] += 1
-        except:
+        except Exception:
             print "Error. Prob last line..."
             print line
             continue

--- a/scripts/binTsTvByPal.py
+++ b/scripts/binTsTvByPal.py
@@ -48,7 +48,7 @@ def summariseVariantCalls(binSize):
                 nTs[pal//binSize] += 1
             else:
                 nTv[pal//binSize] += 1
-        except:
+        except Exception:
             print "Error. Prob last line..."
             print line
             continue

--- a/scripts/computeIndelRatio.py
+++ b/scripts/computeIndelRatio.py
@@ -42,7 +42,7 @@ def summariseVariantCalls():
                 nTransitionSnps += 1
             else:
                 nTransversionSnps += 1
-        except:
+        except Exception:
             #print line
             continue
             #raise

--- a/scripts/computeTsTv.py
+++ b/scripts/computeTsTv.py
@@ -54,7 +54,7 @@ def summariseVariantCalls():
 
                     if filters == "PASS":
                         nPASSTransversionSnps += 1
-        except:
+        except Exception:
             continue
 
     print "nSNP = %s. \t TsTv = %s. PASS TsTv = %s" %(nSNPs,nTransitionSnps/nTransversionSnps,nPASSTransitionSnps/nPASSTransversionSnps)

--- a/scripts/countRefAndNonRefChars.py
+++ b/scripts/countRefAndNonRefChars.py
@@ -9,5 +9,5 @@ for line in sys.stdin:
         nRef = chars.count(".") + chars.count(",")
         nNonRef = chars.count("A") + chars.count("C") + chars.count("T") + chars.count("G")
         print "N ref = %s (%s %%). N non-ref = %s (%s %%)" %(nRef, 100.0*(nRef/lenChars), nNonRef, 100.0*(nNonRef/lenChars))
-    except:
+    except Exception:
         continue

--- a/scripts/filterGOF.py
+++ b/scripts/filterGOF.py
@@ -11,5 +11,5 @@ for line in sys.stdin:
         cols = line.strip().split("\t")
         if int(cols[9].split(":")[-4]) < threshold:
             print line.strip()
-    except:
+    except Exception:
         print line.strip()

--- a/scripts/filterHP.py
+++ b/scripts/filterHP.py
@@ -29,5 +29,5 @@ for line in sys.stdin:
             else:
                 raise StandardError, "Flag should be <,> or = and is %s" %(flag)
 
-    except:
+    except Exception:
         continue

--- a/scripts/filterPal.py
+++ b/scripts/filterPal.py
@@ -29,5 +29,5 @@ for line in sys.stdin:
             else:
                 raise StandardError, "Flag should be <,> or = and is %s" %(flag)
 
-    except:
+    except Exception:
         continue

--- a/scripts/filterTU.py
+++ b/scripts/filterTU.py
@@ -19,5 +19,5 @@ for line in sys.stdin:
             if name == "TU" and len(value) != threshold:
                 print line.strip()
 
-    except:
+    except Exception:
         continue

--- a/scripts/filterTotCoverage.py
+++ b/scripts/filterTotCoverage.py
@@ -12,6 +12,6 @@ for line in sys.stdin:
 
     if nTot >= 15 and nTot <= 50:
         print line.strip()
-    #except:
+    #except Exception:
     #    print line.strip()
     #    continue

--- a/scripts/filterVarCoverage.py
+++ b/scripts/filterVarCoverage.py
@@ -13,5 +13,5 @@ for line in sys.stdin:
 
         if nVar / nTot >= 0.30:
             print line.strip()
-    except:
+    except Exception:
         print line.strip()

--- a/scripts/filterVarFreq.py
+++ b/scripts/filterVarFreq.py
@@ -26,5 +26,5 @@ for line in sys.stdin:
         if TR/TCR > 0.3:
             print line.strip()
 
-    except:
+    except Exception:
         continue

--- a/scripts/keepGof.py
+++ b/scripts/keepGof.py
@@ -11,5 +11,5 @@ for line in sys.stdin:
         cols = line.strip().split("\t")
         if int(cols[9].split(":")[-4]) >= threshold:
             print line.strip()
-    except:
+    except Exception:
         print line.strip()

--- a/scripts/removeHomopolymers.py
+++ b/scripts/removeHomopolymers.py
@@ -27,5 +27,5 @@ for line in sys.stdin:
 
         print line.strip()
 
-    except:
+    except Exception:
         continue

--- a/scripts/removeTandems.py
+++ b/scripts/removeTandems.py
@@ -27,5 +27,5 @@ for line in sys.stdin:
 
         print line.strip()
 
-    except:
+    except Exception:
         continue

--- a/scripts/removeTandemsAndHPs.py
+++ b/scripts/removeTandemsAndHPs.py
@@ -30,5 +30,5 @@ for line in sys.stdin:
 
         print line.strip()
 
-    except:
+    except Exception:
         continue

--- a/src/cython/cpopulation.pyx
+++ b/src/cython/cpopulation.pyx
@@ -615,7 +615,7 @@ cdef class Population:
 
                     try:
                         self.varsByPos[v.refPos].append(v)
-                    except:
+                    except Exception:
                         self.varsByPos[v.refPos] = [v]
 
                 done.add(v)

--- a/src/cython/fastafile.pyx
+++ b/src/cython/fastafile.pyx
@@ -135,7 +135,7 @@ cdef class FastaFile:
 
         try:
             return self.theFile.read(1).upper()
-        except:
+        except Exception:
             return <char*>"-"
 
     cdef void setCacheSequence(self, bytes seqName, long long int beginPos, long long int endPos):

--- a/src/cython/platypusutils.pyx
+++ b/src/cython/platypusutils.pyx
@@ -991,7 +991,7 @@ def getRegions(options):
                         start = int(cols[1])
                         end = int(cols[2])
                         regions.append( (chrom,start,end) )
-                    except:
+                    except Exception:
                         logger.debug("Could not parse line in regions file (%s). Skipping..." %(options.regions[0]))
                         logger.debug("Line was %s" %(line))
                         continue
@@ -1002,7 +1002,7 @@ def getRegions(options):
             header = file.header
             regions = [ (d['SN'], 0, d['LN']) for d in header['SQ'] ]
             logger.debug("Loaded regions from BAM header, SQ tags")
-        except:
+        except Exception:
             logger.debug("Loading regions from FASTA index datas")
 
             for region,regionTuple in refFile.refs.iteritems():
@@ -1029,7 +1029,7 @@ def getRegions(options):
                     pivot = dict(zip([d['SN'] for d in header['SQ']], [d['LN'] for d in header['SQ']]))
                     end = pivot[chrom]
                     regions.append((chrom,int(start)-1,int(end)))
-                except:
+                except Exception:
                     regions = []
                     for region,regionTuple in refFile.refs.iteritems():
                         if region == chrom:

--- a/src/cython/variant.h
+++ b/src/cython/variant.h
@@ -12,6 +12,10 @@
   #endif
 #endif
 
+#ifndef DL_IMPORT
+  #define DL_IMPORT(_T) _T
+#endif
+
 __PYX_EXTERN_C DL_IMPORT(int) PLATYPUS_VAR;
 __PYX_EXTERN_C DL_IMPORT(int) FILE_VAR;
 __PYX_EXTERN_C DL_IMPORT(int) ASSEMBLER_VAR;

--- a/src/python/indelerrormodel.py
+++ b/src/python/indelerrormodel.py
@@ -627,7 +627,7 @@ class IndelHistogram:
     def report(self):
         try:
             self.i += 1
-        except:
+        except Exception:
             self.i = 0
         if self.i % 10000 == 0:
             print "Histogram report:"
@@ -864,7 +864,7 @@ class IndelHistogram:
 
         try:
             base = results[1][1]  # if this fails, there was no data
-        except:
+        except Exception:
             raise ValueError("Too few observations to build error model!")
 
         for repeat_unit in results:

--- a/src/python/lowcov.py
+++ b/src/python/lowcov.py
@@ -699,7 +699,7 @@ def estimateErrorRate( chromosome, motiffile, lowcovbam,
             num += 1
             if num > maxprocessedmotifs: break
 
-    except:
+    except Exception:
         raise
 
     #  create aggregate counts
@@ -728,7 +728,7 @@ def report( counts, coverage ):
         tunit, tlen = key.split(':')
         tlen = int(tlen)
         try:      tunit = int(tunit)
-        except:   pass
+        except Exception:   pass
 
         # fit model to counts
         N00, N01, N11, epsilon, beta = fitmodel( counts[key], coverage )
@@ -759,7 +759,7 @@ def parse_counts( infile ):
         try:
             # convert numbers into ints; leave tandem units alone
             unit = int(unit)
-        except:
+        except Exception:
             pass
 
         key = "%s:%s" % (unit,length)

--- a/src/python/runner.py
+++ b/src/python/runner.py
@@ -45,7 +45,7 @@ class FileForQueueing(object):
         # original names.
         try:
             chrom = int(chrom.upper().strip("CHR"))
-        except:
+        except Exception:
             pass
 
         pos = int(cols[1])
@@ -60,7 +60,7 @@ class FileForQueueing(object):
 
                 try:
                     chrom = int(chrom.upper().strip("CHR"))
-                except:
+                except Exception:
                     pass
 
                 pos = int(cols[1])
@@ -104,7 +104,7 @@ class FileForQueueing(object):
                 # original names.
                 try:
                     chrom = int(chrom.upper().strip("CHR"))
-                except:
+                except Exception:
                     pass
 
                 pos = int(cols[1])

--- a/src/python/runner.py
+++ b/src/python/runner.py
@@ -18,6 +18,7 @@ import logging
 import filez
 import logging.handlers
 import platypusutils
+import time
 
 from variantcaller import PlatypusSingleProcess
 from variantcaller import PlatypusMultiProcess
@@ -452,53 +453,52 @@ def runVariantCaller(options, continuing=False):
     else:
         regions = sorted(platypusutils.getRegions(options), cmp=regionSort)
 
-    if options.nCPU == 1:
-        fileName = None
+    # Always create process manager even if nCPU=1, so that we can listen for signals from the main thread
+    fileNames = set()
+    processes = []
+    regionsForEachProcess = []
 
-        if options.output == "-":
-            fileName = options.output
-        else:
-            fileName = options.output + "_temp_1.gz"
+    # In this case, create all the BAM files here, before splitting into separate processes. The files will be left open until
+    # the end of the parent process, and all child processes will share the same open files via pointers.
+    bamFileNames = None
+    samples = None
+    samplesByID = None
+    samplesByBAM = None
+    bamFiles = None
+    theLocks = None
 
-        p1 = PlatypusSingleProcess(fileName, options, regions, continuing)
-        p1.run()
-        if options.output != "-":
-            mergeVCFFiles([fileName], options.output, log)
-    else:
-        # Create process manager
-        fileNames = set()
-        processes = []
-        regionsForEachProcess = []
+    for i in range(options.nCPU):
+        regionsForEachProcess.append([])
 
-        # In this case, create all the BAM files here, before splitting into separate processes. The files will be left open until
-        # the end of the parent process, and all child processes will share the same open files via pointers.
-        bamFileNames = None
-        samples = None
-        samplesByID = None
-        samplesByBAM = None
-        bamFiles = None
-        theLocks = None
+    for index,region in enumerate(regions):
+        regionsForEachProcess[index % options.nCPU].append(region)
 
-        for i in range(options.nCPU):
-            regionsForEachProcess.append([])
+    for index in range(options.nCPU):
+        #fileName = options.output + "_temp_%s.gz" %(index)
+        fileName = options.output + "_temp_%s" %(index)
+        fileNames.add(fileName)
+        processes.append(PlatypusMultiProcess(fileName, options, regionsForEachProcess[index]))
 
-        for index,region in enumerate(regions):
-            regionsForEachProcess[index % options.nCPU].append(region)
+    for process in processes:
+        process.start()
 
-        for index in range(options.nCPU):
-            #fileName = options.output + "_temp_%s.gz" %(index)
-            fileName = options.output + "_temp_%s" %(index)
-            fileNames.add(fileName)
-            processes.append(PlatypusMultiProcess(fileName, options, regionsForEachProcess[index]))
+    # listen for signals while any process is alive
+    while True in [process.is_alive() for process in processes]:
+        try:
+            time.sleep(1)
+        except KeyboardInterrupt:
+            print "KeyboardInterrupt detected, terminating all processes..."
+            for process in processes:
+                process.terminate()
+            log.error("Variant calling aborted due to keyboard interrupt")
+            sys.exit(1)
 
-        for process in processes:
-            process.start()
+    # make sure all processes are finished
+    for process in processes:
+        process.join()
 
-        for process in processes:
-            process.join()
-
-        # Final output file
-        mergeVCFFiles(fileNames, options.output, log)
+    # Final output file
+    mergeVCFFiles(fileNames, options.output, log)
 
     # All done. Write a message to the log, so that it's clear when the
     # program has actually finished, and not crashed.

--- a/src/python/vcf.py
+++ b/src/python/vcf.py
@@ -74,7 +74,7 @@ def parse_regions( string ):
                 ielts = elts[1].split('-')
                 if len(ielts) != 2: ValueError("Don't understand region string '%s'" % r)
                 try:    start, end = int(ielts[0])-1, int(ielts[1])
-                except: raise ValueError("Don't understand region string '%s'" % r)
+                except Exception: raise ValueError("Don't understand region string '%s'" % r)
         else:
             raise ValueError("Don't understand region string '%s'" % r)
         result.append( (chrom,start,end) )
@@ -413,7 +413,7 @@ class VCF:
             try:
                 if GTstring[0] == '.' or GTstring[2] == '.': return ["."]
                 return [int(GTstring[0]),GTstring[1],int(GTstring[2])]
-            except:
+            except Exception:
                 # hack, to accept "0" genotypes
                 return [int(GTstring[0])]
         try:
@@ -453,7 +453,7 @@ class VCF:
                 for idx,v in enumerate(values):
                     if v == ".": values[idx] = f.missingvalue
                     else:        values[idx] = int(v)
-            except:
+            except Exception:
                 self.error(line,self.ERROR_FORMAT_NOT_NUMERICAL,values)
                 return [0] * len(values)
             return values
@@ -470,7 +470,7 @@ class VCF:
                 for idx,v in enumerate(values):
                     if v == ".":  values[idx] = f.missingvalue
                     else:         values[idx] = float(values[idx])
-            except:
+            except Exception:
                 self.error(line,self.ERROR_FORMAT_NOT_NUMERICAL,values)
                 return [0.0] * len(values)
             return values
@@ -501,7 +501,7 @@ class VCF:
 
         # get 0-based position
         try:    pos = int(cols[1])-1
-        except: self.error(line,self.POS_NOT_NUMERICAL)
+        except Exception: self.error(line,self.POS_NOT_NUMERICAL)
         if pos < 0: self.error(line,self.POS_NOT_POSITIVE)
 
         # implement filtering
@@ -537,7 +537,7 @@ class VCF:
         if cols[5] == ".": qual = -1
         else:
             try:    qual = float(cols[5])
-            except: self.error(line,self.QUAL_NOT_NUMERICAL)
+            except Exception: self.error(line,self.QUAL_NOT_NUMERICAL)
 
         # postpone checking that filters exist.  Encode missing filter or no filtering as empty list
         if cols[6] == "." or cols[6] == "PASS" or cols[6] == "0": filter = []


### PR DESCRIPTION
While performing variant calling, Platypus ignores all KeyboardInterrupts (cython prints `Exception KeyboardInterrupt: ... ignored` messages). This is because runner transfers control of the main thread to the variant calling cython code, which does not run `PyErr_CheckSignals()`. 

Rather than adding signal handling to the cython side of things, I've addressed this in this PR by keeping the main thread python interpreter alive (sleeping for 1 second at a time until all subprocesses are done) and handling any KeyboardExceptions that interrupt that sleep. 

In order to make this work for `nCPU=1`, I've needed to eliminate the special case for that such that a separate processing thread is spawned for the variant caller when nCPU=1 (so technically this means that even with nCPU=1, Platypus would have two processes but one of them would only be performing a few of operations per second). If that is not acceptable, then it might be possible to add another special case to the single process cython such that it implements the signal handlers. 

