### PR TITLE
Fix inline function declarations

### DIFF
--- a/src/c/tandem.c
+++ b/src/c/tandem.c
@@ -57,7 +57,7 @@ unsigned char* twobit(char* sequence, int length, int offset)
 
 //=================================================================================================
 
-inline int approximate_indel_rate_inline(int size, int displacement)
+extern inline int approximate_indel_rate_inline(int size, int displacement)
 {
     // Helper -- returns guess of indel rate, in -10*phred units
     switch (displacement) {
@@ -77,7 +77,7 @@ int approximate_indel_rate(int size, int displacement)
 
 //=================================================================================================
 
-inline int min(int i, int j)
+extern inline int min(int i, int j)
 {
     // Helper -- minimum
     if (i<j) return i;
@@ -86,7 +86,7 @@ inline int min(int i, int j)
 
 //=================================================================================================
 
-inline void foundmatch(char* sizes, char* displacements, int pos, int size, int displacement, int length)
+extern inline void foundmatch(char* sizes, char* displacements, int pos, int size, int displacement, int length)
 {
     // Helper -- decides whether to accept (and store) a match
     char markfull = (length < 0);

--- a/src/tabix/bgzf.c.pysam.c
+++ b/src/tabix/bgzf.c.pysam.c
@@ -75,7 +75,7 @@ static const int GZIP_WINDOW_BITS = -15; // no zlib header
 static const int Z_DEFAULT_MEM_LEVEL = 8;
 
 
-inline
+extern inline
 void
 packInt16(uint8_t* buffer, uint16_t value)
 {
@@ -83,14 +83,14 @@ packInt16(uint8_t* buffer, uint16_t value)
     buffer[1] = value >> 8;
 }
 
-inline
+extern inline
 int
 unpackInt16(const uint8_t* buffer)
 {
     return (buffer[0] | (buffer[1] << 8));
 }
 
-inline
+extern inline
 void
 packInt32(uint8_t* buffer, uint32_t value)
 {

--- a/src/tabix/ksort.h
+++ b/src/tabix/ksort.h
@@ -141,7 +141,7 @@ typedef struct {
 			tmp = *l; *l = l[i]; l[i] = tmp; ks_heapadjust_##name(0, i, l); \
 		}																\
 	}																	\
-	inline void __ks_insertsort_##name(type_t *s, type_t *t)			\
+	extern inline void __ks_insertsort_##name(type_t *s, type_t *t)			\
 	{																	\
 		type_t *i, *j, swap_tmp;										\
 		for (i = s + 1; i < t; ++i)										\


### PR DESCRIPTION
The commit updates declarations of inline functions in the C source
files to comply with the C99 standard by changing `inline` specifiers
to `extern inline`. This change fixes andyrimmer/Platypus#52.